### PR TITLE
adds TransformBase and AffineTransform classes with tests

### DIFF
--- a/neuron_morphology/transforms/affine_transform.py
+++ b/neuron_morphology/transforms/affine_transform.py
@@ -202,7 +202,7 @@ def rotation_from_angle(angle: float, axis: int = 2):
 
         Returns
         -------
-        (4, 4) numpy.ndarray affine matrix
+        (3, 3) numpy.ndarray rotation matrix
 
     """
     c = np.cos(angle)

--- a/neuron_morphology/transforms/affine_transform.py
+++ b/neuron_morphology/transforms/affine_transform.py
@@ -1,0 +1,257 @@
+from typing import Dict, Optional, Any
+
+import numpy as np
+
+from neuron_morphology.morphology import Morphology
+from neuron_morphology.transforms.transform_base import TransformBase
+
+
+class AffineTransform(TransformBase):
+    """Handles transformations to a pia/wm aligned coordinate frame."""
+
+    def __init__(self, affine: Optional[Any] = None):
+        """
+            Represent the transform as a (4,4) np.ndarray affine matrix
+
+            Parameters
+            ----------
+            affine: (4,4) array-like affine transformation
+
+        """
+        if affine is None:
+            self.affine = np.eye(4)
+        else:
+            self.affine = np.asarray(affine)
+            assert self.affine.shape == (4, 4)
+
+    @classmethod
+    def from_dict(cls, affine_dict: Dict[str, float]):
+        """
+            Create an AffineTransform from a dict with keys and values.
+
+            Parameters
+            ----------
+            affine_dict: keys and values corresponding to the following
+                [[tvr_00 tvr_01 tvr_02 tvr_09]
+                 [tvr_03 tvr_04 tvr_05 tvr_10]
+                 [tvr_06 tvr_07 tvr_08 tvr_11]
+                 [0      0      0      1]]
+
+            Returns
+            -------
+            AffineTransform object
+
+        """
+        transform = np.reshape([affine_dict['tvr_%02d' % i] for i in range(9)],
+                               (3, 3))
+        translation = np.reshape([affine_dict['tvr_%02d' % i]
+                                 for i in range(9, 12)], (3, 1))
+        affine = affine_from_transform_translation(transform, translation)
+
+        return cls(affine)
+
+    def to_dict(self) -> Dict:
+        """
+            Create dictionary defining the transformation.
+
+            Returns
+            -------
+            Dict with keys and values corresponding to the following:
+
+                [[tvr_00 tvr_01 tvr_02 tvr_09]
+                 [tvr_03 tvr_04 tvr_05 tvr_10]
+                 [tvr_06 tvr_07 tvr_08 tvr_11]
+                 [0      0      0      1]]
+
+       """
+        affine_dict = {}
+        for i in range(9):
+            affine_dict['tvr_%02d' % i] = self.affine[0:3, 0:3].flatten()[i]
+
+        for i in range(3):
+            affine_dict['tvr_%02d' % (i + 9)] = \
+                self.affine[0:3, 3].flatten()[i]
+
+        return affine_dict
+
+    def transform(self, vector: Any) -> np.ndarray:
+        """
+            Apply this transform to (3,) point or (n,3) array-like of points.
+
+            Parameters
+            ----------
+            vector: a (3,) array-like point or a (n,3) array-like array
+                    of points to be transformed
+
+            Returns
+            -------
+            numpy.ndarray with same shape as input
+
+        """
+        vector = np.asarray(vector)
+        dims = len(vector.shape)
+        if dims == 1:
+            vector = vector.reshape((3, 1))
+        else:
+            vector = vector.T
+
+        vector = np.vstack((vector, np.ones((1, vector.shape[1]))))
+
+        vec_t = np.dot(self.affine, vector)[0:3, :]
+        if dims == 1:
+            vec_t = vec_t.reshape((3,))
+        else:
+            vec_t = vec_t.T
+
+        return vec_t
+
+    def _get_scaling_factor(self) -> float:
+        """
+            Calculate the scaling factor from the affine matrix.
+
+            Returns
+            -------
+            Scaling factor: 3rd root of the determinant.
+
+        """
+        determinant = np.linalg.det(self.affine)
+        return np.power(abs(determinant), 1.0 / 3.0)
+
+    def transform_morphology(self, morphology: Morphology,
+                             clone: bool = False) -> Morphology:
+        """
+            Apply this transform to all nodes in a morphology.
+
+            Parameters
+            ----------
+            morphology: a Morphology loaded from an swc file
+
+            Returns
+            -------
+            A Morphology
+        """
+        if clone:
+            morphology = morphology.clone()
+
+        scaling_factor = self._get_scaling_factor()
+
+        for node in morphology.nodes():
+            coordinates = np.array((node['x'], node['y'], node['z']),
+                                   dtype=float)
+            new_coordinates = self.transform(coordinates)
+            node['x'] = new_coordinates[0]
+            node['y'] = new_coordinates[1]
+            node['z'] = new_coordinates[2]
+            # approximate with uniform scaling in each dimension
+            node['radius'] *= scaling_factor
+
+        return morphology
+
+
+def affine_from_transform_translation(transform: Optional[Any] = None,
+                                      translation: Optional[Any] = None,
+                                      translate_first: bool = False):
+    """
+        Create affine from linear transformation and translation.
+
+        Affine transformation of vector x -> Ax + b in 3D:
+        [A,       b
+         0, 0, 0, 1]
+        A is a 3x3 linear tranformation
+        b is a 3x1 translation
+
+        Parameters
+        ----------
+        transform: linear transformation (3, 3) array-like
+        translation: linear translation (3,) array-like
+        translate_first: apply the translation before the transform
+
+        Returns
+        -------
+        (4, 4) numpy.ndarray affine matrix
+
+    """
+    if transform is None:
+        transform = np.eye(3)
+    else:
+        transform = np.asarray(transform)
+
+    if translation is None:
+        translation = np.zeros((3, 1))
+    else:
+        translation = np.reshape(translation, (3, 1))
+        if translate_first:
+            translation = transform.dot(translation)
+
+    affine = np.zeros((4, 4))
+    affine[0:3, 0:3] = transform
+    affine[0:3, [3]] = translation
+    affine[3, 3] = 1.0
+
+    return affine
+
+
+def rotation_from_angle(angle: float, axis: int = 2):
+    """
+        Create an affine matrix from a rotation about a specific axis.
+
+        Parameters
+        ----------
+        angle: rotation angle in radians
+        axis: axis to rotate about, 0=x, 1=y, 2=z (default z axis)
+
+        Returns
+        -------
+        (4, 4) numpy.ndarray affine matrix
+
+    """
+    c = np.cos(angle)
+    s = np.sin(angle)
+
+    if axis == 0:
+        rot = np.asarray([[1, 0, 0],
+                          [0, c, -s],
+                          [0, s, c]])
+    elif axis == 1:
+        rot = np.asarray([[c, 0, s],
+                          [0, 1, 0],
+                          [-s, 0, c]])
+    elif axis == 2:
+        rot = np.asarray([[c, -s, 0],
+                          [s, c, 0],
+                          [0, 0, 1]])
+    else:
+        raise ValueError('axis must be 0, 1, or 2')
+
+    return rot
+
+
+def affine_from_translation(translation: Any):
+    """
+        Create an affine translation.
+
+        Parameters
+        ----------
+        translation: array-like vector of x, y, and z translations
+
+        Returns
+        -------
+        (4, 4) numpy.ndarray affine matrix
+
+    """
+    return affine_from_transform_translation(translation=translation)
+
+
+def affine_from_transform(transform: Any):
+    """Create affine transformation.
+
+        Parameters
+        ----------
+        transformation: (3, 3) row major array-like transformation
+
+        Returns
+        -------
+        (4, 4) numpy.ndarray affine matrix
+
+    """
+    return affine_from_transform_translation(transform=transform)

--- a/neuron_morphology/transforms/transform_base.py
+++ b/neuron_morphology/transforms/transform_base.py
@@ -1,0 +1,33 @@
+import abc
+
+from neuron_morphology.morphology import Morphology
+
+
+class TransformBase(abc.ABC):
+    """
+        Abstract base class for implementing swc transforms.
+        Each child class should implement these methods.
+    """
+    @abc.abstractmethod
+    def transform_morphology(self) -> Morphology:
+        """
+            Apply this transform to all nodes in a morphology.
+
+            Returns
+            -------
+            A Morphology
+
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def transform(self):
+        """
+            Apply this transform to (3,) point or (3,n) array-like of points.
+
+            Returns
+            -------
+            numpy.ndarray with same shape as input
+
+        """
+        raise NotImplementedError()

--- a/tests/transforms/test_affine_transform.py
+++ b/tests/transforms/test_affine_transform.py
@@ -1,0 +1,147 @@
+import unittest
+
+import numpy as np
+
+from neuron_morphology.morphology_builder import MorphologyBuilder
+from neuron_morphology.transforms.affine_transform import (
+    AffineTransform, rotation_from_angle, affine_from_translation,
+    affine_from_transform, affine_from_transform_translation)
+
+
+class TestAffine(unittest.TestCase):
+
+    def setUp(self):
+        """
+        y+
+        |
+        P
+        ^
+        P
+        ^
+        S > A > A - x+
+        """
+        self.morphology = (
+            MorphologyBuilder()
+                .root(0, 0, 0)
+                    .axon(1, 0, 0)
+                        .axon(2, 0, 0).up(2)
+                    .apical_dendrite(0, 1, 0)
+                        .apical_dendrite(0, 2, 0)
+                .build()
+            )
+        self.point = [0, 1, 0]
+        self.vector = [[0, 0, 0],
+                       [1, 0, 0],
+                       [2, 0, 0],
+                       [0, 1, 0],
+                       [0, 2, 0]]
+        """
+        [[tvr_00 tvr_01 tvr_02 tvr_09]
+         [tvr_03 tvr_04 tvr_05 tvr_10]
+         [tvr_06 tvr_07 tvr_08 tvr_11]
+         [0      0      0      1]]
+        """
+        rad = 60 * np.pi / 180
+        self.rad = rad
+        self.array = [[np.cos(rad), -np.sin(rad), 0, 0],
+                      [np.sin(rad), np.cos(rad), 0, 10],
+                      [0, 0, 1, 0],
+                      [0, 0, 0, 1]]
+
+        self.translation = [0, 10, 0]
+        self.dict = {'tvr_00': np.cos(rad),
+                     'tvr_01': -np.sin(rad),
+                     'tvr_02': 0,
+                     'tvr_03': np.sin(rad),
+                     'tvr_04': np.cos(rad),
+                     'tvr_05': 0,
+                     'tvr_06': 0,
+                     'tvr_07': 0,
+                     'tvr_08': 1,
+                     'tvr_09': 0,
+                     'tvr_10': 10,
+                     'tvr_11': 0,
+                     }
+        self.transformed_vector = [[0, 10, 0],
+                                   [0.5, 10 + np.sqrt(3) / 2, 0],
+                                   [1, 10 + np.sqrt(3), 0],
+                                   [-np.sqrt(3)/2, 10.5, 0],
+                                   [-np.sqrt(3), 11, 0]]
+
+    def test_init_affine_empty(self):
+        assert np.allclose(AffineTransform().affine,
+                           np.eye(4))
+
+    def test_init_affine_matrix_from_array(self):
+        assert np.allclose(AffineTransform(self.array).affine,
+                           self.array)
+
+    def test_init_affine_from_dict(self):
+        assert np.allclose(AffineTransform.from_dict(self.dict).affine,
+                           self.array)
+
+    def test_affine_to_dict(self):
+        affine_dict = AffineTransform(self.array).to_dict()
+        for key, value in self.dict.items():
+            self.assertAlmostEqual(value, affine_dict[key])
+
+    def test_transform_point(self):
+        affine_transform = AffineTransform(self.array)
+        assert np.allclose(affine_transform.transform(self.point),
+                           np.asarray([-np.sqrt(3)/2, 10.5, 0]))
+
+    def test_transform_vector(self):
+        affine_transform = AffineTransform(self.array)
+        assert np.allclose(affine_transform.transform(self.vector),
+                           np.asarray(self.transformed_vector))
+
+    def test_transform_morphology(self):
+        transformed_nodes = (AffineTransform(self.array)
+                             .transform_morphology(self.morphology)
+                             .nodes())
+
+        for node in transformed_nodes:
+            assert np.allclose([node['x'], node['y'], node['z']],
+                               self.transformed_vector[node['id']])
+
+
+class TestAffineConstructors(unittest.TestCase):
+
+    def setUp(self):
+        self.point = [1, 0, 0]
+        self.translation = [10, 0, 0]
+        self.rad = 60 * np.pi / 180
+        self.c = np.cos(self.rad)
+        self.s = np.sin(self.rad)
+        self.transform = [[self.c, -self.s, 0], [self.s, self.c, 0], [0, 0, 1]]
+
+    def affine_from_transform_translation_1st(self):
+        affine = affine_from_transform_translation(transform=self.transform,
+                                                   translation=self.translation,
+                                                   translate_first=True)
+        assert np.allclose(AffineTransform(affine).transform(self.point),
+                           [11 / 2, 11 * np.sqrt(3) / 2, 0])
+
+    def affine_from_transform_translation_2nd(self):
+        affine = affine_from_transform_translation(transform=self.transform,
+                                                   translation=self.translation)
+        assert np.allclose(AffineTransform(affine).transform(self.point),
+                           [1 / 2 + 10, np.sqrt(3) / 2, 0])
+
+    def test_rotation_from_angle(self):
+        assert np.allclose(rotation_from_angle(self.rad),
+                           self.transform)
+
+    def test_affine_from_translation(self):
+        assert np.allclose(affine_from_translation(self.translation),
+                           [[1, 0, 0, 10],
+                            [0, 1, 0, 0],
+                            [0, 0, 1, 0],
+                            [0, 0, 0, 1]])
+
+    def test_affine_from_transform(self):
+        assert np.allclose(affine_from_transform(self.transform),
+                           [[self.c, -self.s, 0, 0],
+                            [self.s, self.c, 0, 0],
+                            [0, 0, 1, 0],
+                            [0, 0, 0, 1]])

--- a/tests/transforms/test_transform_base.py
+++ b/tests/transforms/test_transform_base.py
@@ -1,0 +1,40 @@
+import unittest
+
+from neuron_morphology.transforms.transform_base import TransformBase
+
+
+class TestTransformBase(unittest.TestCase):
+
+    def test_cannot_instantiate(self):
+        with self.assertRaises(TypeError):
+            TransformBase()
+
+    def test_missing_transform_method(self):
+
+        class ConcreteTransform(TransformBase):
+            def transform_morphology(self):
+                return "implements transform_morphology but not transform"
+
+        with self.assertRaises(TypeError):
+            ConcreteTransform()
+
+    def test_missing_transform_morphology_method(self):
+
+        class ConcreteTransform(TransformBase):
+            def transform(self):
+                return "implements transform but not transform_morphology"
+
+        with self.assertRaises(TypeError):
+            ConcreteTransform()
+
+    def test_concrete(self):
+
+        class ConcreteTransform(TransformBase):
+            def transform_morphology(self):
+                return "implements transform_morphology"
+
+            def transform(self):
+                return "implements transform"
+
+        ConcreteTransform()
+        assert True


### PR DESCRIPTION
Keeping the core functionality that was in 1205/create-pia-transform. Will eventually update the comparison notebooks and rebase 22/upright-comparison-framework off of dev, and remove 1205 altogether.