### PR TITLE
#25 rtd yaml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,10 +22,10 @@ What actually happened. If the bug produced an error message or incorrect values
 **Environment (please complete the following information):**
  - OS & version: [e.g. Ubuntu 18.04]
  - Python version [e.g. 3.7]
- - AllenSDK version [e.g. v1.0.0]
+ - neuron_morphology version [e.g. v1.0.0]
 
 **Additional context**
 Add any other context about the problem here.
 
 **Do you want to work on this issue?**
-Are you willing and able to fix this bug? If so, let us know here (and see [the guide](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)). Thank you!
+Are you willing and able to fix this bug? If so, let us know here (and see [the guide](https://github.com/AllenInstitute/neuron_morphology/blob/master/CONTRIBUTING.md)). Thank you!

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -20,4 +20,4 @@ Any alternative solutions or features you've considered.
 Add any other information about the feature request here.
 
 **Do you want to work on this issue?**
-Are you willing and able to work on this feature? If so, let us know here (and see [the guide](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)). Thank you!
+Are you willing and able to work on this feature? If so, let us know here (and see [the guide](https://github.com/AllenInstitute/neuron_morphology/blob/master/CONTRIBUTING.md)). Thank you!

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 .venv/
 /venv/
 /doc_build/
+/doc/
 /doc_source/
 
 # PyInstaller

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,19 @@
+
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+sphinx:
+  builder: html
+
+python:
+   version: 3.8
+   install:
+      # - requirements: requirements.txt
+      - requirements: doc_requirements.txt
+
+formats:
+  - epub
+  - pdf

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,6 @@ sphinx:
 python:
    version: 3.8
    install:
-      # - requirements: requirements.txt
       - requirements: doc_requirements.txt
 
 formats:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,4 +7,3 @@ include neuron_morphology/logging_config.ini
 
 recursive-include tests *
 recursive-include bin *
-recursive-include allensdk/neuron_morphology/rendering/templates *

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = doc_source
-BUILDDIR      = doc_build
+BUILDDIR      = doc
 TEMPLATEDIR   = doc_template
 
 # Put it first so that "make" without argument is like "make help".

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,2 +1,14 @@
 sphinx<3.0.0
 numpydoc<1.0.0
+matplotlib
+pillow
+pandas
+numpy>=1.14.2
+scipy>=1.0.0
+six
+git+https://github.com/alleninstitute/argschema@input_source_2.0.1 # TODO: make sure this feature gets into a release (or stop using it)
+glymur<1.0.0 # If you want to actually use glymur, you must also have openjpeg installed. The easiest way is "conda install openjpeg"
+rasterio<2.0.0
+shapely<2.0.0
+imageio<3.0.0
+pg8000<2.0.0 # required for running from the Allen Institute's internal database

--- a/doc_template/conf.py
+++ b/doc_template/conf.py
@@ -77,6 +77,8 @@ html_show_sphinx = False # TODO: alabaster seems to be ignoring this directive
 
 master_doc = "index"
 
+autodoc_mock_imports = ["allensdk"]
+
 
 # setup
 def run_apidoc(*a):

--- a/doc_template/conf.py
+++ b/doc_template/conf.py
@@ -75,6 +75,8 @@ html_static_path = ['_static']
 # additional options
 html_show_sphinx = False # TODO: alabaster seems to be ignoring this directive
 
+master_doc = "index"
+
 
 # setup
 def run_apidoc(*a):


### PR DESCRIPTION
docs are building on readthedocs, see e.g.:
https://neuron-morphology.readthedocs.io/en/readthedocs/