### PR TITLE
Bugfix/bounding box orientation

### DIFF
--- a/neuron_morphology/snap_polygons/__main__.py
+++ b/neuron_morphology/snap_polygons/__main__.py
@@ -44,11 +44,6 @@ def run_snap_polygons(
     clear_overlaps(raster_stack)
     closest, closest_names = closest_from_stack(raster_stack)
 
-    import matplotlib.pyplot as plt
-    fig, ax = plt.subplots()
-    plt.imshow(closest)
-    plt.savefig("tmp.png")
-
     snapped_polys = get_snapped_polys(closest, closest_names)
 
     result_geos = Geometries()

--- a/neuron_morphology/snap_polygons/__main__.py
+++ b/neuron_morphology/snap_polygons/__main__.py
@@ -43,6 +43,12 @@ def run_snap_polygons(
     raster_stack = working_geo.rasterize()
     clear_overlaps(raster_stack)
     closest, closest_names = closest_from_stack(raster_stack)
+
+    import matplotlib.pyplot as plt
+    fig, ax = plt.subplots()
+    plt.imshow(closest)
+    plt.savefig("tmp.png")
+
     snapped_polys = get_snapped_polys(closest, closest_names)
 
     result_geos = Geometries()
@@ -50,9 +56,9 @@ def run_snap_polygons(
 
     result_geos = (result_geos
         .transform(
-            lambda vt, hr: (
-                vt + working_geo.close_bounds.vorigin,
-                hr + working_geo.close_bounds.horigin
+            lambda ht, vt: (
+                ht + working_geo.close_bounds.horigin,
+                vt + working_geo.close_bounds.vorigin
             )
         )
         .transform(make_scale(1.0 / working_scale))

--- a/neuron_morphology/snap_polygons/bounding_box.py
+++ b/neuron_morphology/snap_polygons/bounding_box.py
@@ -14,10 +14,10 @@ class BoundingBox:
     # (then scale and convert to int at a requested resolution when necessary)
     def __init__(
         self, 
-        vorigin: float, 
         horigin: float, 
+        vorigin: float, 
+        hextent: float,
         vextent: float, 
-        hextent: float
     ):
         """ Represents the bounds of a set of 2D objects
 
@@ -37,8 +37,8 @@ class BoundingBox:
 
     def __repr__(self):
         return (
-            f"BoundingBox({self.vorigin}, {self.horigin}, "
-            f"{self.vextent}, {self.hextent})"
+            f"BoundingBox({self.horigin}, {self.vorigin}, "
+            f"{self.hextent}, {self.vextent})"
         )
 
     @property
@@ -55,22 +55,22 @@ class BoundingBox:
     
     @property
     def origin(self):
-        return [self.vorigin, self.horigin]
+        return [self.horigin, self.vorigin]
 
     @property
     def extent(self):
-        return [self.vextent, self.hextent]
+        return [self.hextent, self.vextent]
 
     @property
     def coordinates(self):
-        return [self.vorigin, self.horigin, self.vextent, self.hextent]
+        return [self.horigin, self.vorigin, self.hextent, self.vextent]
 
     def update(
         self, 
-        vorigin: float, 
         horigin: float, 
+        vorigin: float, 
+        hextent: float,
         vextent: float, 
-        hextent: float
     ):
         """ Potentially enlarges this box.
 
@@ -112,10 +112,10 @@ class BoundingBox:
         else:
             obj = self.copy()
 
-        obj.vorigin, obj.horigin = transform(
-            obj.vorigin, obj.horigin)
-        obj.vextent, obj.hextent = transform(
-            obj.vextent, obj.hextent)
+        obj.horigin, obj.vorigin = transform(
+            obj.horigin, obj.vorigin)
+        obj.hextent, obj.vextent = transform(
+            obj.hextent, obj.vextent)
         
         return obj
 
@@ -129,8 +129,8 @@ class BoundingBox:
         """
 
         return self.__class__(
-            self.vorigin, self.horigin, 
-            self.vextent, self.hextent
+            self.horigin, self.vorigin, 
+            self.hextent, self.vextent
         )
 
     def round(

--- a/neuron_morphology/snap_polygons/geometries.py
+++ b/neuron_morphology/snap_polygons/geometries.py
@@ -55,12 +55,9 @@ class Geometries:
         """
 
         polygon = ensure_polygon(path)
-        # ho, vo, he, ve = polygon.bounds
-        # self.close_bounds.update(vo, ho, ve, he)
         self.close_bounds.update(*polygon.bounds)
 
         self.polygons[name] = polygon
-
 
     def _register_many(
         self, 
@@ -112,17 +109,14 @@ class Geometries:
         """
 
         surface = ensure_linestring(path)
-        ho, vo, he, ve = surface.bounds
-        self.close_bounds.update(vo, ho, ve, he)
+        self.close_bounds.update(*surface.bounds)
 
         self.surfaces[name] = surface
-
 
     def register_surfaces(self, surfaces: Dict[str, LineType]):
         """ utility for registering multiple surfaces. See register_surface
         """
         self._register_many(surfaces, self.register_surface)
-
 
     def rasterize(
         self, 
@@ -231,7 +225,7 @@ def rasterize(
     """
 
     box = box.round(origin_via=math.floor, extent_via=math.ceil)
-    translate = lambda v, h: (v - box.vorigin, h - box.horigin)
+    translate = lambda ht, vt: (ht - box.horigin, vt - box.vorigin)
     geometry = shapely.ops.transform(translate, geometry)
     out_shape = (box.height, box.width)
 
@@ -256,7 +250,7 @@ def make_scale(
     A transform function
 
     """
-    return lambda vertical, horizontal: (vertical * scale, horizontal * scale)
+    return lambda horizontal, vertical: (horizontal * scale, vertical * scale)
 
 def clear_overlaps(stack: Dict[str, np.ndarray]):
     """ Given a stack of masks, remove all inter-mask overlaps inplace

--- a/neuron_morphology/snap_polygons/image_outputter.py
+++ b/neuron_morphology/snap_polygons/image_outputter.py
@@ -24,7 +24,7 @@ class ImageOutputter:
         self, 
         native_geo: Geometries, 
         result_geo: Geometries, 
-        image_specs: Sequence[Dict],
+        image_specs: Optional[Sequence[Dict]],
         alpha: float = 0.4,
         color_cycle: Optional[Sequence] = None,
         savefig_kwargs: Optional[Dict] = None
@@ -55,7 +55,7 @@ class ImageOutputter:
 
         self.native_geo = native_geo
         self.result_geo = result_geo
-        self.image_specs = image_specs
+        self.image_specs = image_specs or []
 
         self.alpha = alpha
         self.color_cycle = color_cycle

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib
-pillow
+pillow<7.1.0 # excluding this version since it seems to break imageio's png reading
 pandas
 numpy>=1.14.2
 scipy>=1.0.0

--- a/tests/snap_polygons/test_bounding_box.py
+++ b/tests/snap_polygons/test_bounding_box.py
@@ -35,7 +35,7 @@ class TestBoundingBox(TestCase):
     def test_copy(self):
         new = self.box.copy()
         new.vorigin = 12
-        self.assertEqual(self.box.vorigin, 10)
+        self.assertEqual(self.box.vorigin, 20)
 
     def test_round(self):
         box = BoundingBox(10.5, 20, 30, 40.5)

--- a/tests/snap_polygons/test_geometries.py
+++ b/tests/snap_polygons/test_geometries.py
@@ -85,7 +85,7 @@ class TestUtilities(TestCase):
 
         obt = go.rasterize(
             Polygon([(0, 0), (0, 5), (5, 5), (5, 0), (0, 0)]),
-            BoundingBox(0, 0, 7, 3)
+            BoundingBox(0, 0, 3, 7)
         )
 
         assert np.allclose(


### PR DESCRIPTION
This fixes a bug discovered by @gouwens, where xy ordering was not being treated consistently when transforming shapely polygons vs. bounding boxes. This bug can cause the resulting polygons to be cut off.

To fix it (and simplify coordinate handling), I swapped the order of the horizontal and vertical components in bounding box, so that they now match shapely.