### PR TITLE
basic docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,60 @@
+# ide specific
+.idea/
+.history/
+.vscode/
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+.venv/
+/venv/
+/doc_build/
+/doc/
+/doc_source/
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+htmlcov/
+.pytest_cache
+
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.pyc
+*$py.class
+
+# linters
+/.mypy_cache
+
+# notebooks
+**/.ipynb_checkpoints

--- a/.dockerignore
+++ b/.dockerignore
@@ -58,3 +58,6 @@ __pycache__/
 
 # notebooks
 **/.ipynb_checkpoints
+
+# docker
+/docker/*

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,11 +1,15 @@
 FROM continuumio/miniconda3
 
-RUN apt-get install -y libhdf5-dev
+# dolfin (dep of fenics) uses a jit, so we need this at runtime
+RUN apt-get install -y g++
 
-RUN conda create --name py38 python=3.8 -y
+# some allensdk requirements, such as tables and statsmodels, don't have py38 
+# binary wheels for the versions pinned in allensdk. Building these images 
+# becomes much slower if we must build those wheels ourselves, so we are using
+# python 3.7 until allensdk's requirements are upgraded.
+RUN conda create --name py37 python=3.7 -y
 
-RUN activate py38 && \
-    conda install -y -c conda-forge fenics mshr
+RUN conda run -n py37 conda install -y -c conda-forge fenics mshr
 
 RUN conda clean -ayv && \
     find /opt/conda -follow -type f -regex '*\.(a)|(pyc)' -delete

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,0 +1,11 @@
+FROM continuumio/miniconda3
+
+RUN apt-get install -y libhdf5-dev
+
+RUN conda create --name py38 python=3.8 -y
+
+RUN activate py38 && \
+    conda install -y -c conda-forge fenics mshr
+
+RUN conda clean -ayv && \
+    find /opt/conda -follow -type f -regex '*\.(a)|(pyc)' -delete

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -12,4 +12,4 @@ RUN conda create --name py37 python=3.7 -y
 RUN conda run -n py37 conda install -y -c conda-forge fenics mshr
 
 RUN conda clean -ayv && \
-    find /opt/conda -follow -type f -regex '*\.(a)|(pyc)' -delete
+    find /opt/conda -follow -type f -regextype posix-extended -regex '.*\.((a)|(pyc))' -delete

--- a/docker/Dockerfile.deploy
+++ b/docker/Dockerfile.deploy
@@ -1,0 +1,12 @@
+FROM neuron_morphology/base
+
+ADD . /neuron_morphology
+WORKDIR /neuron_morphology
+
+RUN activate py38 && \
+    pip install -U -r optional_requirements.txt && \
+    pip install -U -r requirements.txt && \
+    pip install -U .
+
+RUN conda clean -ayv && \
+    find /opt/conda -follow -type f -regex '*\.(a)|(pyc)' -delete

--- a/docker/Dockerfile.deploy
+++ b/docker/Dockerfile.deploy
@@ -10,4 +10,4 @@ RUN conda run -n py37 pip install -U .
 RUN conda run -n py37 python -c "import numpy; print(numpy.__version__)"
 
 RUN conda clean -ayv && \
-    find /opt/conda -follow -type f -regex '*\.(a)|(pyc)' -delete
+    find /opt/conda -follow -type f -regextype posix-extended -regex '.*\.((a)|(pyc))' -delete

--- a/docker/Dockerfile.deploy
+++ b/docker/Dockerfile.deploy
@@ -3,10 +3,11 @@ FROM neuron_morphology/base
 ADD . /neuron_morphology
 WORKDIR /neuron_morphology
 
-RUN activate py38 && \
-    pip install -U -r optional_requirements.txt && \
-    pip install -U -r requirements.txt && \
-    pip install -U .
+RUN conda run -n py37 pip install -U -r optional_requirements.txt
+RUN conda run -n py37 pip install -U -r requirements.txt
+RUN conda run -n py37 pip install -U .
+
+RUN conda run -n py37 python -c "import numpy; print(numpy.__version__)"
 
 RUN conda clean -ayv && \
     find /opt/conda -follow -type f -regex '*\.(a)|(pyc)' -delete

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,8 @@
+docker
+======
+We use these images for our production pipeline. `Dockerfile.base` is a longstanding root image (separated to speed up builds). `Dockerfile.deploy` is the per-build image.
+
+To build these, `cd` to the neuron_morphology root directory and run:
+```
+docker build . -f docker/Dockerfile.<something> -t neuron_morphology/<something>:<version>
+```


### PR DESCRIPTION
addresses part of #117

These are larger than I would like. I did some basic pruning stages (conda clean, removing static libs and pycs, but the dependencies are just ... large. We could consider splitting up by purpose (so that not every image has fenics + mshr for instance). If we can build those in parallel, I think it would be worth it.

Another solution we could investigate is the use of alpine. [Here is an image](https://github.com/jcrist/alpine-dask-docker/blob/master/alpine-conda/Dockerfile) which uses conda on alpine. When I tested it out it did not make an enormous difference (since most of the size of the image is due to python packages).