### PR TITLE
allow null for slice_transform

### DIFF
--- a/neuron_morphology/pipeline/_schemas.py
+++ b/neuron_morphology/pipeline/_schemas.py
@@ -110,7 +110,8 @@ class InputParameters(ArgSchema):
         Float,
         cli_as_single_argument=True,
         description='List defining the transform defining slice cut angle',
-        required=True
+        required=True,
+        allow_none=True,
     )
 
     slice_image_flip = Boolean(


### PR DESCRIPTION
to correct the error raised in the post_data_to_s3
marshmallow.exceptions.ValidationError: {'slice_transform': ['Field may not be null.']}