### PR TITLE
Add backed-off retries to ecs tasks

### DIFF
--- a/pipeline/commands/landing.py
+++ b/pipeline/commands/landing.py
@@ -84,11 +84,11 @@ def landing(token: Optional[str] = None):
         "bucket_name": working_bucket,
         "reconstruction_id": reconstruction_id,
         "run_id": run_id,
-        "run_tilt": (metadata['slice_transform'] is not None),
         "now": now,
         "raw_swc_key": get_raw_swc_key(
             working_bucket, base_key, reconstruction_id
-        )
+        ),
+        "run_tilt": (metadata.get("slice_transform", None) is not None)
     }
 
 

--- a/pipeline/deploy/cloudformation/morphology_pipeline.yml
+++ b/pipeline/deploy/cloudformation/morphology_pipeline.yml
@@ -521,7 +521,7 @@ Resources:
                 },
                 "Retry": [
                   {
-                    "ErrorEquals": ["ECS.AmazonECSException"],
+                    "ErrorEquals": ["ECS.AmazonECSException", "ECS.InvalidParameterException"],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 8,
                     "BackoffRate": 2.0
@@ -572,7 +572,7 @@ Resources:
                 },
                 "Retry": [
                   {
-                    "ErrorEquals": ["ECS.AmazonECSException"],
+                    "ErrorEquals": ["ECS.AmazonECSException", "ECS.InvalidParameterException"],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 8,
                     "BackoffRate": 2.0
@@ -623,7 +623,7 @@ Resources:
                 },
                 "Retry": [
                   {
-                    "ErrorEquals": ["ECS.AmazonECSException"],
+                    "ErrorEquals": ["ECS.AmazonECSException", "ECS.InvalidParameterException"],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 8,
                     "BackoffRate": 2.0
@@ -674,7 +674,7 @@ Resources:
                 },
                 "Retry": [
                   {
-                    "ErrorEquals": ["ECS.AmazonECSException"],
+                    "ErrorEquals": ["ECS.AmazonECSException", "ECS.InvalidParameterException"],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 8,
                     "BackoffRate": 2.0
@@ -729,7 +729,7 @@ Resources:
                 },
                 "Retry": [
                   {
-                    "ErrorEquals": ["ECS.AmazonECSException"],
+                    "ErrorEquals": ["ECS.AmazonECSException", "ECS.InvalidParameterException"],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 8,
                     "BackoffRate": 2.0
@@ -800,7 +800,7 @@ Resources:
                 },
                 "Retry": [
                   {
-                    "ErrorEquals": ["ECS.AmazonECSException"],
+                    "ErrorEquals": ["ECS.AmazonECSException", "ECS.InvalidParameterException"],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 8,
                     "BackoffRate": 2.0

--- a/pipeline/deploy/cloudformation/morphology_pipeline.yml
+++ b/pipeline/deploy/cloudformation/morphology_pipeline.yml
@@ -519,6 +519,14 @@ Resources:
                     }
                   }
                 },
+                "Retry": [
+                  {
+                    "ErrorEquals": ["ECS.AmazonECSException"],
+                    "IntervalSeconds": 2,
+                    "MaxAttempts": 8,
+                    "BackoffRate": 2.0
+                  }
+                ],
                 "ResultPath": "$.landing",
                 "Next": "PlotOriginal"
               },

--- a/pipeline/deploy/cloudformation/morphology_pipeline.yml
+++ b/pipeline/deploy/cloudformation/morphology_pipeline.yml
@@ -570,6 +570,14 @@ Resources:
                     }
                   }
                 },
+                "Retry": [
+                  {
+                    "ErrorEquals": ["ECS.AmazonECSException"],
+                    "IntervalSeconds": 2,
+                    "MaxAttempts": 8,
+                    "BackoffRate": 2.0
+                  }
+                ],
                 "ResultPath": "$.plot_original",
                 "Next": "DepthField"
               },
@@ -613,6 +621,14 @@ Resources:
                     }
                   }
                 },
+                "Retry": [
+                  {
+                    "ErrorEquals": ["ECS.AmazonECSException"],
+                    "IntervalSeconds": 2,
+                    "MaxAttempts": 8,
+                    "BackoffRate": 2.0
+                  }
+                ],
                 "ResultPath": "$.depth_field",
                 "Next": "ScaleCorrection"
               },
@@ -656,6 +672,14 @@ Resources:
                     }
                   }
                 },
+                "Retry": [
+                  {
+                    "ErrorEquals": ["ECS.AmazonECSException"],
+                    "IntervalSeconds": 2,
+                    "MaxAttempts": 8,
+                    "BackoffRate": 2.0
+                  }
+                ],
                 "ResultPath": "$.scale",
                 "Next": "UprightTransform"
               },
@@ -703,6 +727,14 @@ Resources:
                     }
                   }
                 },
+                "Retry": [
+                  {
+                    "ErrorEquals": ["ECS.AmazonECSException"],
+                    "IntervalSeconds": 2,
+                    "MaxAttempts": 8,
+                    "BackoffRate": 2.0
+                  }
+                ],
                 "ResultPath": "$.upright_transform",
                 "Next": "TiltChoice"
               },
@@ -766,6 +798,14 @@ Resources:
                     }
                   }
                 },
+                "Retry": [
+                  {
+                    "ErrorEquals": ["ECS.AmazonECSException"],
+                    "IntervalSeconds": 2,
+                    "MaxAttempts": 8,
+                    "BackoffRate": 2.0
+                  }
+                ],
                 "ResultPath": "$.tilt",
                 "Next": "MigrateOutputs"
               },


### PR DESCRIPTION
This gets around the 10 task submissions / 10 seconds limit described in issue #151. Using this branch I've submitted 40 jobs as close to simultaneously as I can manage without failures (from this limit).

I also changed the slice_transform handling in landing. It now defaults to None if the key is not present. This is a fully independent change.

Hmm, cranking up the submissions to 100 results in an error resulting from EC2 request limits. This is `ECS.InvalidParameterException` (as reported to step functions) rather than `ECS.AmazonECSException` so ... add it to the retrier I suppose.
EDIT: that does the trick