### PR TITLE
Adding statistical feature to capture "mean and stdev of bifurcation distances" 

### DIFF
--- a/neuron_morphology/features/statistics/moment_along_max_distance_projection.py
+++ b/neuron_morphology/features/statistics/moment_along_max_distance_projection.py
@@ -77,3 +77,6 @@ def moment_along_max_distance_projection(
 
     return summary_dict
 
+
+
+

--- a/neuron_morphology/features/statistics/moment_along_max_distance_projection.py
+++ b/neuron_morphology/features/statistics/moment_along_max_distance_projection.py
@@ -76,3 +76,4 @@ def moment_along_max_distance_projection(
                 'kurt': kurt}
 
     return summary_dict
+

--- a/neuron_morphology/features/statistics/moment_along_max_distance_projection.py
+++ b/neuron_morphology/features/statistics/moment_along_max_distance_projection.py
@@ -1,0 +1,78 @@
+from typing import Optional, List
+
+import numpy as np
+from scipy import stats
+from scipy.spatial import distance
+
+from neuron_morphology.feature_extractor.data import Data
+from neuron_morphology.features.statistics.coordinates import COORD_TYPE
+
+from neuron_morphology.feature_extractor.marked_feature import marked
+from neuron_morphology.feature_extractor.mark import Geometric,RequiresRoot
+
+
+@marked(Geometric) 
+@marked(RequiresRoot)
+def moment_along_max_distance_projection(
+            data: Data,
+            node_types: Optional[List] = None,
+            coord_type: COORD_TYPE = COORD_TYPE.BIFURCATION,
+            ):
+    """
+        Calculate the distance projections of a specific comparment and coordinate type along
+        the line segment connecting soma to the most distant (from soma) node of that comparment. 
+        
+        Parameters
+        ----------
+        data: Data Object containing a morphology
+        node_types: a list of node types (see neuron_morphology constants)
+        coord_type: Restrict which coordinate types are measured (i.e. projected along line segment)           
+                            (see neuron_morphology.features.statistics.coordinates for options)
+                            
+        Returns
+        -------  
+        summary_dict: summary stats of distances projected along specified line segment 
+    """
+    
+    morphology = data.morphology
+    find_most_distant_coordinates = COORD_TYPE.NODE.get_coordinates(morphology, node_types=node_types)
+    measuring_coordinates = coord_type.get_coordinates(morphology, node_types=node_types)
+    
+    if (not find_most_distant_coordinates) or (not measuring_coordinates):
+        nan_array = np.empty((3,))
+        nan_array[:] = np.nan
+        summary_dict = {
+            'mean': nan_array,
+            'std': nan_array,
+            'var': nan_array,
+            'skew': nan_array,
+            'kurt': nan_array}
+        
+    else:
+        measuring_coordinates = np.asarray(measuring_coordinates)
+        soma_node = morphology.get_soma()
+        soma_coord = np.array([soma_node['x'],soma_node['y'],soma_node['z']])
+
+        max_distance = -1
+        for coord in find_most_distant_coordinates:
+            dist = distance.euclidean(coord,soma_coord)
+            if dist>max_distance:
+                max_distance = dist
+                furthest_coord = coord
+                
+        projected_dists = np.dot( (furthest_coord - soma_coord).T, (measuring_coordinates - soma_coord).T )
+        norm = np.linalg.norm(furthest_coord - soma_coord)
+        
+        distances = projected_dists/norm
+        distances /= max_distance
+        (_, _, mean, variance, skew, kurt) = stats.describe(distances, axis=0)
+        stdv = np.std(distances)
+    
+        summary_dict = {
+                'mean': mean,
+                'std': stdv,
+                'var': variance,
+                'skew': skew,
+                'kurt': kurt}
+
+    return summary_dict

--- a/tests/feature_extractor/statistic_features/test_moment_along_max_distance_projection_feature.py
+++ b/tests/feature_extractor/statistic_features/test_moment_along_max_distance_projection_feature.py
@@ -1,0 +1,139 @@
+import unittest
+
+import numpy as np
+
+from neuron_morphology.morphology import Morphology
+from neuron_morphology.constants import (
+    AXON, APICAL_DENDRITE, BASAL_DENDRITE, SOMA
+)
+from neuron_morphology.feature_extractor.data import Data
+from neuron_morphology.features.statistics.coordinates import COORD_TYPE_SPECIALIZATIONS
+from neuron_morphology.features.statistics import moment_along_max_distance_projection as mo_proj
+from neuron_morphology.feature_extractor.feature_extractor import FeatureExtractor
+from neuron_morphology.feature_extractor.feature_specialization import (
+    NEURITE_SPECIALIZATIONS)
+from neuron_morphology.feature_extractor.marked_feature import nested_specialize
+
+
+class TestMaxDistProjMoment(unittest.TestCase):
+
+    def setUp(self):
+
+        # Create an axon that extends positively,
+        # and a basal dendrite that extends negatively
+        self.one_dim_neuron = Morphology([
+                {
+                    "id": 0,
+                    "parent_id": -1,
+                    "type": SOMA,
+                    "x": 0,
+                    "y": 100,
+                    "z": 0,
+                    "radius": 10
+                },
+                # Axon node [100, 125, 150, 200, 200]
+                {
+                    "id": 1,
+                    "parent_id": 0,
+                    "type": AXON,
+                    "x": 0,
+                    "y": 125,
+                    "z": 0,
+                    "radius": 3
+                },
+                {
+                    "id": 2,
+                    "parent_id": 1,
+                    "type": AXON,
+                    "x": 0,
+                    "y": 150,
+                    "z": 0,
+                    "radius": 3
+                },
+                {
+                    "id": 3,
+                    "parent_id": 2,
+                    "type": AXON,
+                    "x": 0,
+                    "y": 200,
+                    "z": 0,
+                    "radius": 3
+                },
+                {
+                    "id": 4,
+                    "parent_id": 3,
+                    "type": AXON,
+                    "x": 0,
+                    "y": 200,
+                    "z": 0,
+                    "radius": 3
+                },
+                # Basal node [100, 75, 50, 50]
+                {
+                    "id": 11,
+                    "parent_id": 0,
+                    "type": BASAL_DENDRITE,
+                    "x": 0,
+                    "y": 100,
+                    "z": 0,
+                    "radius": 3
+                },
+                {
+                    "id": 12,
+                    "parent_id": 11,
+                    "type": BASAL_DENDRITE,
+                    "x": 0,
+                    "y": 75,
+                    "z": 0,
+                    "radius": 3
+                },
+                {
+                    "id": 13,
+                    "parent_id": 12,
+                    "type": BASAL_DENDRITE,
+                    "x": 0,
+                    "y": 50,
+                    "z": 0,
+                    "radius": 3
+                },
+                {
+                    "id": 14,
+                    "parent_id": 13,
+                    "type": BASAL_DENDRITE,
+                    "x": 0,
+                    "y": 50,
+                    "z": 0,
+                    "radius": 3
+                },
+            ],
+            node_id_cb=lambda node: node["id"],
+            parent_id_cb=lambda node: node["parent_id"],
+        )
+
+        self.one_dim_neuron_data = Data(self.one_dim_neuron)
+
+        self.moment_features = nested_specialize(
+            mo_proj.moment_along_max_distance_projection,
+            [COORD_TYPE_SPECIALIZATIONS, NEURITE_SPECIALIZATIONS])
+
+    def extract(self, feature):
+        extractor = FeatureExtractor([feature])
+        return (
+            extractor.extract(self.one_dim_neuron_data).results
+        )
+
+    def test_axon_compartment_moments(self):
+        expected_axon_compartment_moments = {
+            'mean': 0.625,
+            'std': 0.2795085,
+            'var': 0.1041667,
+            'skew': 0.0,
+            'kurt': -1.36
+        }
+        axon_compartment_moments = \
+            self.extract(self.moment_features)["axon.compartment.moments"]
+
+        for key in axon_compartment_moments.keys():
+            self.assertIsNone(np.testing.assert_allclose(
+                axon_compartment_moments[key],
+                expected_axon_compartment_moments[key]))


### PR DESCRIPTION
Created script to calculate the IVSCC feature "mean and stdev bifurcation distance" . This is the mean and standard deviation of relative positions projected to a line connecting the soma to the furthest node (from the soma) of selected compartment. 

Added flexibility to calculate same metric for other coordinate and compartment types. 