### PR TITLE
Snap polygons updates

### DIFF
--- a/doc_template/install.rst
+++ b/doc_template/install.rst
@@ -14,7 +14,7 @@ Two popular tools for managing Python environments are `anaconda <https://anacon
 
 .. code-block:: bash
 
-    conda create -y --name environment-name python=3.6
+    conda create -y --name environment-name python=3.7
     conda activate environment-name
 
 and using venv:

--- a/neuron_morphology/lims_apical_queries.py
+++ b/neuron_morphology/lims_apical_queries.py
@@ -20,10 +20,10 @@ def convert_coords_str(coords_str: str, resolution=None):
 
 
 def get_data(query):
-    host = os.getenv("DBHOST")
-    dbname = os.getenv("DBNAME")
-    user = os.getenv("DBREADER")
-    password = os.getenv("DBPASSWORD")
+    host = os.getenv("LIMS_HOST")
+    dbname = os.getenv("LIMS_DBNAME")
+    user = os.getenv("LIMS_USER")
+    password = os.getenv("LIMS_PASSWORD")
     conn_str = f'host={host} dbname={dbname} user={user} password={password}'
 
     data = {}

--- a/neuron_morphology/snap_polygons/__main__.py
+++ b/neuron_morphology/snap_polygons/__main__.py
@@ -83,20 +83,19 @@ def run_snap_polygons(
     return results
 
 
+class Parser(ArgSchemaParser):
+    """An ArgschemaParser that can pull data from LIMS
+    """
+    default_sources = \
+        ArgSchemaParser.default_sources + (FromLimsSource,)
+    default_schema=InputParameters
+    default_output_schema=OutputParameters
+
 def main():
     """CLI entrypoint for snapping polygons
     """
 
-    class Parser(ArgSchemaParser):
-        """An ArgschemaParser that can pull data from LIMS
-        """
-        default_configurable_sources = \
-            ArgSchemaParser.default_configurable_sources + [FromLimsSource]
-
-    parser = Parser(
-        schema_type=InputParameters,
-        output_schema_type=OutputParameters
-    )
+    parser = Parser()
 
     args = cp.deepcopy(parser.args)
     logging.getLogger().setLevel(args.pop("log_level"))

--- a/neuron_morphology/snap_polygons/__main__.py
+++ b/neuron_morphology/snap_polygons/__main__.py
@@ -35,9 +35,6 @@ def run_snap_polygons(
     """
     if len(layer_polygons)==0:
         raise ValueError("No polygons provided.")
-    layer_names = [layer['name'] for layer in layer_polygons]
-    if len(layer_names) != len(set(layer_names)):
-        raise ValueError("Duplicate layer names.")
     # setup input geometries
     geometries = Geometries()
     geometries.register_polygons(layer_polygons)

--- a/neuron_morphology/snap_polygons/_from_lims.py
+++ b/neuron_morphology/snap_polygons/_from_lims.py
@@ -154,7 +154,7 @@ def query_for_cortical_surfaces(
             "name": item["name"],
             "path": ensure_path(item["path"])
         }
-    return results["Pia"], results["White Matter"]
+    return results.get("Pia"), results.get("White Matter")
     
 
 def query_for_images(

--- a/neuron_morphology/snap_polygons/_from_lims.py
+++ b/neuron_morphology/snap_polygons/_from_lims.py
@@ -58,7 +58,7 @@ def query_for_layer_polygons(
     """
 
     query = f"""
-        select
+        select distinct
             st.acronym as name,
             polygon.path as path,
             polygon.id as polygon_id
@@ -105,11 +105,6 @@ def query_for_layer_polygons(
                     raise ValueError(
                         f"found multiple distinct layer drawings for {name}"
                     )
-            else:
-                warnings.warn(
-                    f"found multiple polygon records for {name} "
-                    "(identical paths)"
-                )
 
         polygons.append({
             "name": name,

--- a/neuron_morphology/snap_polygons/_from_lims.py
+++ b/neuron_morphology/snap_polygons/_from_lims.py
@@ -268,20 +268,23 @@ class PostgresInputConfigSchema(DefaultSchema):
 
     host = String(
         description="",
-        required=True
+        required=False,
+        default=os.environ.get("LIMS_HOST")
     )
     database = String(
         description="",
-        required=True
+        required=False,
+        default=os.environ.get("LIMS_DBNAME")
     )
     user = String(
         description="",
-        required=True
+        required=False,
+        default=os.environ.get("LIMS_USER")
     )
     password = String(
         description="",
         required=False,
-        default=os.environ.get("POSTGRES_SOURCE_PASSWORD")
+        default=os.environ.get("LIMS_PASSWORD")
     )
     port = Int(
         description="",

--- a/neuron_morphology/snap_polygons/_from_lims.py
+++ b/neuron_morphology/snap_polygons/_from_lims.py
@@ -19,10 +19,10 @@ import os
 import warnings
 import logging
 
-import marshmallow as mm
 
+from argschema.schemas import DefaultSchema
 from argschema.fields import Int, OutputDir, String
-from argschema.sources import ArgSource
+from argschema.sources import ConfigurableSource
 from allensdk.internal.core import lims_utilities as lu
 
 from neuron_morphology.snap_polygons.types import (
@@ -262,7 +262,7 @@ def get_inputs_from_lims(
     return results
 
 
-class PostgresInputConfigSchema(mm.Schema):
+class PostgresInputConfigSchema(DefaultSchema):
     """The parameters required to query a postgres database.
     """
 
@@ -285,7 +285,7 @@ class PostgresInputConfigSchema(mm.Schema):
     )
     port = Int(
         description="",
-        required=False,  # seems not to get hydrated from the default
+        required=False, 
         default=5432
     )
 
@@ -307,20 +307,21 @@ class FromLimsSchema(PostgresInputConfigSchema):
     )
 
 
-class FromLimsSource(ArgSource):
+class FromLimsSource(ConfigurableSource):
     """ An alternate argschema source which gets its inputs from lims directly
     """
 
     ConfigSchema = FromLimsSchema
 
     def get_dict(self):
-        image_output = getattr(self, "image_output_root", None)
+        config = self.config
+        image_output = getattr(config, "image_output_root", None)
         return get_inputs_from_lims(
-            self.host,  # pylint: disable=no-member
-            self.port,  # pylint: disable=no-member
-            self.database,  # pylint: disable=no-member
-            self.user,  # pylint: disable=no-member
-            self.password,  # pylint: disable=no-member,
-            self.focal_plane_image_series_id,  # pylint: disable=no-member
+            config["host"],  # pylint: disable=no-member
+            config["port"],  # pylint: disable=no-member
+            config["database"],  # pylint: disable=no-member
+            config["user"],  # pylint: disable=no-member
+            config["password"],  # pylint: disable=no-member,
+            config["focal_plane_image_series_id"],  # pylint: disable=no-member
             image_output  # pylint: disable=no-member
         )

--- a/neuron_morphology/snap_polygons/_from_lims.py
+++ b/neuron_morphology/snap_polygons/_from_lims.py
@@ -246,13 +246,11 @@ def get_inputs_from_lims(
 
     layer_polygons = query_for_layer_polygons(engine, imser_id)
     pia_surface, wm_surface = query_for_cortical_surfaces(engine, imser_id)
-    image_width, image_height = query_for_image_dims(engine, imser_id)
 
     results = {
         "layer_polygons": layer_polygons,
         "pia_surface": pia_surface,
         "wm_surface": wm_surface,
-        "image_dimensions": {"width": image_width, "height": image_height}
     }
 
     if image_output_root is not None:
@@ -318,13 +316,12 @@ class FromLimsSource(ConfigurableSource):
 
     def get_dict(self):
         config = self.config
-        image_output = getattr(config, "image_output_root", None)
         return get_inputs_from_lims(
-            config["host"],  # pylint: disable=no-member
-            config["port"],  # pylint: disable=no-member
-            config["database"],  # pylint: disable=no-member
-            config["user"],  # pylint: disable=no-member
-            config["password"],  # pylint: disable=no-member,
-            config["focal_plane_image_series_id"],  # pylint: disable=no-member
-            image_output  # pylint: disable=no-member
+            config["host"],
+            config["port"],
+            config["database"],
+            config["user"],
+            config["password"],
+            config["focal_plane_image_series_id"],
+            config.get("image_output_root")
         )

--- a/neuron_morphology/snap_polygons/_schemas.py
+++ b/neuron_morphology/snap_polygons/_schemas.py
@@ -68,14 +68,18 @@ class InputParameters(ArgSchema):
     pia_surface = Nested(
         SimpleGeometry,
         description="A path defining the pia-side surface of the cortex",
-        required=True
+        required=True,
+        default=None,
+        allow_none=True
     )
     wm_surface = Nested(
         SimpleGeometry,
         description=(
             "A path defining the white matter-side surface of the cortex"
         ),
-        required=True
+        required=False,
+        default=None,
+        allow_none=True
     )
     working_scale = Float(
         description=(

--- a/neuron_morphology/snap_polygons/geometries.py
+++ b/neuron_morphology/snap_polygons/geometries.py
@@ -512,14 +512,13 @@ def clear_overlaps(stack: Dict[str, np.ndarray]):
 
 
 def closest_from_stack(stack: Dict[str, np.ndarray]):
-    """ Given a stack of images describing distance from several objects, find
-    the closest object to each pixel.
+    """ Given a stack of image masks representing several objects, find
+    the closest object to each pixel in the image space.
 
     Parameters
     ----------
-    stack : Keys are names, values are ndarrays (of the same shape). Each pixel
-        in the values describes the distance from that pixel to the named 
-        object
+    stack : Keys are names, values are masks (of the same shape). 0 indicates
+        absence 
 
     Returns
     -------
@@ -576,8 +575,10 @@ def find_vertical_surfaces(
         pia: Optional[LineString] = None,
         white_matter: Optional[LineString] = None
 ):
-    """ Given a set of polygons describing cortical layer boundaries, find the
+    """ Given a set of polygons describing cortical layers, find the
     boundaries between each layer.
+    Pia and white matter surfaces are optional, used for pia-side of top layer
+    and wm-side of bottom layer. Otherwise, these are not assigned.
 
     Parameters
     ----------
@@ -601,18 +602,22 @@ def find_vertical_surfaces(
     for index, name in enumerate(names):
         current = polygons[name]
         # up side
-        if index == 0 and pia is not None:
-            results[f"{name}_pia"] = pia
+        if index == 0:
+            top = pia
         else:
             above_layers = [polygons[name] for name in names[:index]]
-            results[f"{name}_pia"] = shared_faces(current, above_layers)
+            top = shared_faces(current, above_layers)
+        if top is not None:
+           results[f"{name}_pia"] = top
 
         # down side
-        if index == len(names) - 1 and white_matter is not None:
-            results[f"{name}_wm"] = white_matter
+        if index == len(names) - 1:
+            bottom = white_matter
         else:
             below_layers = [polygons[name] for name in names[index + 1:]]
-            results[f"{name}_wm"] = shared_faces(current, below_layers)
+            bottom = shared_faces(current, below_layers)
+        if bottom is not None:
+           results[f"{name}_wm"] = bottom
 
     return results
 
@@ -630,7 +635,7 @@ def shared_faces(poly: Polygon, others: Iterable[Polygon]) -> LineString:
 
     Returns
     -------
-    LineString representing the shared face
+    LineString representing the shared face, or None if not found
     """
 
     faces_list = []
@@ -646,6 +651,8 @@ def shared_faces(poly: Polygon, others: Iterable[Polygon]) -> LineString:
         if not faces.is_empty:
             faces_list.append(faces)
 
+    if not faces_list:
+        return None
     merged_faces = shapely.ops.linemerge(faces_list)
     coordinates = list(merged_faces.coords)
     shared_line = ensure_linestring(coordinates)

--- a/tests/snap_polygons/test_geometries.py
+++ b/tests/snap_polygons/test_geometries.py
@@ -208,7 +208,7 @@ class TestUtilities(TestCase):
             [(1.0, 1.0), (1.0, 3.0), (3.0, 3.0), (3.0, 1.0), (1.0, 1.0)]
         )
 
-    def find_vertical_surfaces(self):
+    def test_find_vertical_surfaces(self):
         polys = {
             "layer1": Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)]),
             "layer2": Polygon([(0, 1), (1, 1), (1, 2), (0, 2), (0, 1)])


### PR DESCRIPTION
Addresses #190 and #189 
much of this is dedicated to fixing and improving the FromLimsSource functionality (#190) :
- updating the argschema references to the current naming
- updating the schema to use the AllenSDK-matched environment variable credentials as defaults, and fixing some other mismatches between schema and code
- expose the parser so it can used by other code not running snap_polygons as a script
- fix the LIMS query to not select duplicate layer drawings (this is the norm, not an exceptional case)

also addresses @189 by:
- providing an alternate code path that doesn't require pia/wm paths, skipping the trimming of layers to those paths' bounds
- clarifies the behavior of find_vertical_surfaces, which also uses the pia/wm paths when available to annotate the top of L1 and bottom of L6
- also updates a few other docstrings that had confusing or wrong descriptions of steps in the process.