### PR TITLE
bumping argschema off an alpha release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ numpy>=1.14.2
 scipy>=1.0.0
 six
 allensdk
-argschema==3.0.0a0
+argschema==3.0.1
 glymur<1.0.0 # If you want to actually use glymur, you must also have openjpeg installed. The easiest way is "conda install openjpeg"
 shapely<2.0.0
 imageio<3.0.0


### PR DESCRIPTION
I think this version is on PYPI now