### PR TITLE
Fix for newer fenicsx ufl

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,6 +9,7 @@ environment:
 install:
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%MINICONDA%\\Library\\bin;%PATH%"
   - conda config --set always_yes yes --set changeps1 no
+  - conda install tqdm
   - conda update -q conda
   - conda install openjpeg # for glymur
   - pip install -r test_requirements.txt -U

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           name: create conda env
           command: |
             if [ ! -d ~/.conda_envs/build_env_wfenics ]; then
-              conda create -c conda-forge fenics-dolfinx gmsh python-gmsh \
+              conda create -c conda-forge fenics-dolfinx gmsh python-gmsh cairo \
               python=3.8 \
               -p ~/.conda_envs/build_env_wfenics/
             fi

--- a/neuron_morphology/transforms/streamline.py
+++ b/neuron_morphology/transforms/streamline.py
@@ -13,6 +13,7 @@ from neuron_morphology.transforms.geometry import (
 
 
 def solve_laplace_2d(V: fem.FunctionSpace,
+                     domain,
                      bcs: List[fem.bcs.DirichletBCMetaClass]):
     """
         Solves the laplace equation with boundary conditions bcs on V
@@ -25,7 +26,7 @@ def solve_laplace_2d(V: fem.FunctionSpace,
 
     u = ufl.TrialFunction(V)
     v = ufl.TestFunction(V)
-    f = fem.Constant(V, ScalarType(0)) # no source for the Laplace equation
+    f = fem.Constant(domain, ScalarType(0)) # no source for the Laplace equation
     a = ufl.dot(ufl.grad(u), ufl.grad(v)) * ufl.dx
     L = f * v * ufl.dx
 
@@ -147,7 +148,7 @@ def generate_laplace_field(top_line: List[Tuple],
     bcs = [bc_top, bc_bottom]
 
     # Solve for value field
-    u = solve_laplace_2d(V, bcs)
+    u = solve_laplace_2d(V, domain, bcs)
 
     # Get derivative
     grad_u = compute_gradient(u, W)  # grad_u = Grad

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ numpy>=1.14.2
 scipy>=1.0.0
 six
 allensdk
-argschema>=3<=4
+argschema
 glymur<1.0.0 # If you want to actually use glymur, you must also have openjpeg installed. The easiest way is "conda install openjpeg"
 shapely<2.0.0
 imageio<3.0.0


### PR DESCRIPTION
Modification to work with the new ufl library used by the latest fenicsx/dolfinx (0.6). It's backwards compatible with at least 0.5.2 as well (and probably earlier).