### PR TITLE
Update requirements

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,7 @@ install:
   - conda install tqdm
   - conda update -q conda
   - conda install openjpeg # for glymur
+  - pip install -U ruamel.yaml
   - pip install -r test_requirements.txt -U
   - pip install -r requirements.txt -U
   - pip install .

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,7 +4,7 @@ build: false
 environment:
   matrix:
     - MINICONDA: C:\Miniconda38-x64
-      PYTHON: 3.8
+      PYTHON: 3.9
 
 install:
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%MINICONDA%\\Library\\bin;%PATH%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,8 +11,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda install tqdm
   - conda update -q conda
-  - conda install openjpeg # for glymur
-  - pip install -U ruamel.yaml
+  - conda install openjpeg ruamel.yaml # for glymur
   - pip install -r test_requirements.txt -U
   - pip install -r requirements.txt -U
   - pip install .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,8 @@ jobs:
           name: create conda env
           command: |
             if [ ! -d ~/.conda_envs/build_env_wfenics ]; then
-              conda create -c conda-forge fenics-dolfinx gmsh python-gmsh cairo \
-              python=3.8 \
+              conda create -c conda-forge fenics-dolfinx python-gmsh cairo \
+              python=3.9 \
               -p ~/.conda_envs/build_env_wfenics/
             fi
             conda activate ~/.conda_envs/build_env_wfenics
@@ -106,12 +106,12 @@ jobs:
             bash ~/miniconda.sh -b -p $HOME/miniconda
             source $HOME/miniconda/bin/activate
             conda init zsh
-            conda init 
+            conda init
             if [ ! -d ~/.conda_envs/build_env_wfenics ]; then
                         cd $HOME
 
-              conda create -y -c conda-forge fenics-dolfinx gmsh python-gmsh hdf5 scikit-image \
-              python=3.8 \
+              conda create -y -c conda-forge fenics-dolfinx python-gmsh hdf5 scikit-image \
+              python=3.9 \
               -p ~/.conda_envs/build_env_wfenics/
             fi
             conda activate ~/.conda_envs/build_env_wfenics

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib
-pillow<7.1.0 # excluding this version since it seems to break imageio's png reading
+pillow
 pandas
 numpy>=1.14.2
 scipy>=1.0.0
@@ -12,3 +12,5 @@ imageio<3.0.0
 pg8000<2.0.0 # required for running from the Allen Institute's internal database
 boto3>=1.12.42
 cloud-files
+scikit-image>0.17
+tables>=3.8


### PR DESCRIPTION
- unpinning pillow, png loading issue has since been resolved 
- older versions of scikit image install with 3.9 require numpy to be already installed making fresh environment install of neuron_morphology fail #https://github.com/scikit-image/scikit-image/issues/5060 # 
- older versions of tables would fail with 3.9
- updating circleci/appveyor to python 3.9 