### PR TITLE
clear gmsh between initializations

### DIFF
--- a/neuron_morphology/transforms/streamline.py
+++ b/neuron_morphology/transforms/streamline.py
@@ -98,6 +98,7 @@ def generate_laplace_field(top_line: List[Tuple],
 
     # Create mesh with gmsh
     gmsh.initialize()
+    gmsh.clear()
 
     # Set up the points
     point_tags = [gmsh.model.geo.addPoint(x, y, 0, meshSize=mesh_res)


### PR DESCRIPTION
this fixes an error when running multiple times in a row in a docker container. meshes were not being cleared between runs which caused failures and small differences in results every run. 